### PR TITLE
Add support for client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ optional arguments:
                         Certificate file to use for SSL/TLS interception
   -k <key>, --key <key>
                         Private key file to use for SSL/TLS interception
+  -cc <cert>, --clientcert <cert>
+                        Client certificate file to use for connecting to server
+  -ck <key>, --clientkey <key>
+                        Client private key file to use for connecting to server
 ```
 
 # User scripts


### PR DESCRIPTION
I used your useful tool in a situation where I needed a client certificate to connect to server. I modified it a bit to add support.