### PR TITLE
Tls fix

### DIFF
--- a/mitm_relay.py
+++ b/mitm_relay.py
@@ -226,7 +226,7 @@ def do_relay_tcp(client_sock, server_sock, cfg):
 
 	# ssl.PROTOCOL_TLS is available only since 2.7.13
 	# in order to support older versions let's fall back to what is default
-	#cfg_ssl_version = ssl.PROTOCOL_TLS
+	cfg_ssl_version = ssl.PROTOCOL_SSLv23
 
 	if cfg.tlsver:
 		if cfg.tlsver == "tls1":

--- a/mitm_relay.py
+++ b/mitm_relay.py
@@ -224,7 +224,10 @@ def do_relay_tcp(client_sock, server_sock, cfg):
 	server_peer = server_sock.getpeername()
 	client_peer = client_sock.getpeername()
 
-	cfg_ssl_version = ssl.PROTOCOL_TLS
+	# ssl.PROTOCOL_TLS is available only since 2.7.13
+	# in order to support older versions let's fall back to what is default
+	#cfg_ssl_version = ssl.PROTOCOL_TLS
+
 	if cfg.tlsver:
 		if cfg.tlsver == "tls1":
 			cfg_ssl_version = ssl.PROTOCOL_TLSv1


### PR DESCRIPTION
With the most common python version tls set up may fail:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "mitm_relay.py", line 383, in handle_tcp_client
    do_relay_tcp(client_sock, server_sock, cfg)
  File "mitm_relay.py", line 227, in do_relay_tcp
    cfg_ssl_version = ssl.PROTOCOL_TLS
AttributeError: 'module' object has no attribute 'PROTOCOL_TLS'
```
Ubuntu LTS 16.04.06 ships this version:

Python 2.7.12 (default, Nov 12 2018, 14:36:49)

According to https://docs.python.org/2/library/ssl.html#ssl.PROTOCOL_TLS the variable `ssl.PROTOCOL_TLS` is only available since 2.7.13

In order to support older version the explicit initialization has been commented out to fall back to what is default in the system 