### PR TITLE
Added option to dump TLS (pre-)master keys for e.g. decrypting PCAPs …

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The normal request traffic flow during typical usage would be as below:
 
 ```
 usage: mitm_relay.py [-h] [-l <listen>] -r <relay> [<relay> ...] [-s <script>]
-                     [-p <proxy>] [-c <cert>] [-k <key>]
+                     [-p <proxy>] [-c <cert>] [-k <key>] [-cc <clientcert>]
+                     [-ck <clientkey>] [-t <tls1|tls11|tls12|ssl2|ssl3>]
+                     [-sk <ssl keylog file>]
 
 mitm_relay version 0.40
 
@@ -55,10 +57,16 @@ optional arguments:
                         Certificate file to use for SSL/TLS interception
   -k <key>, --key <key>
                         Private key file to use for SSL/TLS interception
-  -cc <cert>, --clientcert <cert>
-                        Client certificate file to use for connecting to server
-  -ck <key>, --clientkey <key>
-                        Client private key file to use for connecting to server
+  -cc <clientcert>, --clientcert <clientcert>
+                        Client certificate file to use for connecting to
+                        server
+  -ck <clientkey>, --clientkey <clientkey>
+                        Client private key file to use for connecting to
+                        server
+  -t <tls1|tls11|tls12|ssl2|ssl3>, --tlsver <tls1|tls11|tls12|ssl2|ssl3>
+                        Force SSL/TLS version
+  -sk <ssl keylog file>, --sslkeylog <ssl keylog file>
+                        Dump SSL (pre-)master secrets to <ssl keylog file>
 ```
 
 # User scripts
@@ -82,7 +90,7 @@ def handle_request(client_request):
 
   # Example: remove compression on an IMAP session
   modified_request = client_request.replace('COMPRESS=DEFLATE', 'COMPRESS=NONE')
-  
+
   return modified_request
 ```
 
@@ -161,4 +169,3 @@ Screenshot: SMB/CIFS Traffic interception:
 Screenshot: Disabling compression on a Gmail IMAP session to capture plain text exchanges:
 
 ![IMAP](https://i.imgur.com/LuF4GG0.png)
-

--- a/mitm_relay.py
+++ b/mitm_relay.py
@@ -98,6 +98,14 @@ def main():
 		dest='tlsver',
 		help='Force SSL/TLS version',
 		default=False)
+	parser.add_argument('-sk', '--sslkeylog',
+		action='store',
+		metavar='<ssl keylog file>',
+		dest='sslkeylog',
+		type=argparse.FileType('a'),
+		help='Dump SSL (pre-)master secrets to <ssl keylog file>',
+		default=False)
+
 
 	cfg = parser.parse_args()
 	cfg.prog_name = __prog_name__
@@ -144,6 +152,16 @@ def main():
 		except Exception as e:
 			print color("[!] %s" % str(e))
 			sys.exit()
+	# If a ssl keylog file was specified, dump (pre-)master secrets
+	if cfg.sslkeylog:
+		try:
+			import sslkeylog
+			sslkeylog.set_keylog(cfg.sslkeylog)
+
+		except Exception as e:
+			print color("[!] %s" % str(e))
+			sys.exit()
+
 
 	server_threads = []
 	for relay in cfg.relays:


### PR DESCRIPTION
…in Wireshark (useful for raw TCP and UDP protocols)

During an engagement I had to intercept TLS-encrypted MQTT. And since manually decoding the raw MQTT binary data stream is quite tedious, I added the an option to dump SSL/TLS (pre-)master keys (using the [sslkeylog](https://pypi.org/project/sslkeylog/) Python module) in order to decrypt the live captured traffic in Wireshark.