### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ optional arguments:
                         Proxy to forward all requests/responses to. If
                         omitted, traffic will only be printed to the console
                         (monitoring mode unless a script is specified).
-                        Format: host:port
+                        Format: [scheme://]host:port
+                        in case the error :
+                        "[!] Not supported proxy scheme None"
+                        try scheme://host:port instead
+
+
   -c <cert>, --cert <cert>
                         Certificate file to use for SSL/TLS interception
   -k <key>, --key <key>


### PR DESCRIPTION
just to clarify the  need to specify scheme:// for python 3.9 or it would have error message: "[!] Not supported proxy scheme None"