### PR TITLE
gen_certs: Create './cert' output directory

### DIFF
--- a/gen_certs.sh
+++ b/gen_certs.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
-openssl genrsa -out cert/private.key 2048
-openssl req -new -x509 -days 3650 -key cert/private.key -out cert/server.pem -subj "/CN=*.acmecorp.com"
+#!/bin/sh
+certdir="cert"
+mkdir -p "${certdir}"
+openssl genrsa -out "${certdir}/private.key" 2048
+openssl req -new -x509 -days 3650 -key "${certdir}/private.key" -out "${certdir}/server.pem" -subj "/CN=*.acmecorp.com"


### PR DESCRIPTION
* Create `cert` output directory before attempting to generate files
* Replace `/bin/bash` shebang shell with `/bin/sh` (this script is simple and should work in any shell)
* `chmod gen_certs/sh`. Simple quality of life improvement.
* Use a `certdir` variable to hold the directory name. This allows changing the output directory in only one location. The obvious downside is that the commands can no longer be copied easily from the script. But users can easily run the command from the readme instead. Also, the commands are easy to read and modify if necessary.
